### PR TITLE
Remove "video.ui.exe" from internal_microsoft_exes_exact

### DIFF
--- a/src/window-helpers.cpp
+++ b/src/window-helpers.cpp
@@ -358,7 +358,6 @@ static const char *internal_microsoft_exes_exact[] = {
 	"systemsettings.exe",
 	"textinputhost.exe",
 	"searchapp.exe",
-	"video.ui.exe",
 	"searchui.exe",
 	"lockapp.exe",
 	"cortana.exe",


### PR DESCRIPTION
fix https://github.com/bozbez/win-capture-audio/issues/73