### PR TITLE
Fix bug that UWP app can't be selected by HOTKEY

### DIFF
--- a/src/audio-capture.cpp
+++ b/src/audio-capture.cpp
@@ -86,8 +86,9 @@ static void start_capture(audio_capture_context_t *ctx)
 		error("%s", e.what());
 	}
 
-	ctx->process = open_process(PROCESS_QUERY_INFORMATION | SYNCHRONIZE,
-				    false, ctx->process_id);
+	ctx->process =
+		open_process(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE,
+			     false, ctx->process_id);
 
 	if (ctx->process == NULL)
 		warn("failed to open target process, can't detect termination");


### PR DESCRIPTION
fix https://github.com/bozbez/win-capture-audio/issues/80

```
HWND new_window = GetForegroundWindow();
if (is_uwp_window(new_window)) 
	new_window = get_uwp_actual_window(new_window);
```

By the way, I reduced the locked region for config_section.
Besides, I replaced PROCESS_QUERY_INFORMATION with PROCESS_QUERY_LIMITED_INFORMATION. 