### PR TITLE
Log plugin version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ configure_file(
     installer/installer.iss.in
     ../installer/installer.generated.iss
 )
+configure_file(
+    src/plugin-macros.h.in
+    ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.h
+)
 
 find_package(LibObs REQUIRED)
 

--- a/src/plugin-macros.h.in
+++ b/src/plugin-macros.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define PLUGIN_VERSION "@CMAKE_PROJECT_VERSION@"

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,4 +1,6 @@
 #include <obs-module.h>
+#include "common.hpp"
+#include "plugin-macros.generated.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("win-capture-audio", "en-GB")
@@ -7,6 +9,7 @@ extern struct obs_source_info audio_capture_info;
 
 bool obs_module_load(void)
 {
+	blog(LOG_INFO, "[win-capture-audio] Version %s", PLUGIN_VERSION);
 	obs_register_source(&audio_capture_info);
 	return true;
 }


### PR DESCRIPTION
Adds a log of the plugin version according to the version set in cmake which makes support easier.
Intentionally doesn't use the `info` macro since the function isn't needed here.

Example on current master:
```
15:04:52.748: [win-capture-audio] Version 2.2.1
```

