### PR TITLE
Update Brazilian Portuguese locale

### DIFF
--- a/data/locale/pt-BR.ini
+++ b/data/locale/pt-BR.ini
@@ -1,16 +1,16 @@
-Name="Captura de saída de áudio da aplicação"
+Name="Captura de saída de áudio de aplicativo"
 
 Mode="Modo"
-# Mode.Session=""
+Mode.Session="Capturar sessões de áudio de uma seleção de executáveis"
 Mode.Hotkey="Capturar a janela em primeiro plano com uma tecla de atalho"
 
-# ExecutableList=""
+ExecutableList="Executáveis"
 
-# ActiveSession.Group=""
-# ActiveSession.List=""
-# ActiveSession.Add=""
+ActiveSession.Group="Adicionar de sessões ativas"
+ActiveSession.List="Sessão"
+ActiveSession.Add="Adicionar executável"
 
-# Exclude=""
+Exclude="Capturar todo o áudio EXCETO sessões dos executáveis selecionados"
 
 Hotkey.Start="Capturar janela em primeiro plano"
 Hotkey.Stop="Desativar captura"


### PR DESCRIPTION
Previous pt-BR translation was incomplete. This changes adds the missing key values and updates the `Name` key with better grammar.